### PR TITLE
Add support for creating document & node with namespace

### DIFF
--- a/document.go
+++ b/document.go
@@ -9,12 +9,22 @@ const (
 )
 
 func NewDocument(name string) *Document {
+	return NewDocumentWithNS(name, nil)
+}
+
+func NewDocumentWithNS(name string, ns *Namespace) *Document {
 	d := &Document{
 		ProcInst: DEFAULT_XML_HEADER,
 	}
+
+	if ns != nil {
+		d.NamespaceList = []*Namespace{ns}
+	}
+
 	d.Root = &Node{
 		Document: d,
 		Name:     name,
+		NS:       ns,
 	}
 	return d
 }

--- a/node.go
+++ b/node.go
@@ -121,8 +121,34 @@ func (n *Node) NextSibling() *Node {
 }
 
 func (n *Node) CreateNode(name string) *Node {
+	return n.CreateNodeWithNS(name, nil)
+}
+
+// CreateNodeWithNS will create a node with the requested namespace.
+// If the namespace already exists (matching by URI) then the pre-existing
+// namespace will be used, *even if the name is different.*
+func (n *Node) CreateNodeWithNS(name string, ns *Namespace) *Node {
+	if ns != nil {
+		found := false
+
+		if n.Document.NamespaceList != nil {
+			for _, existingNS := range n.Document.NamespaceList {
+				if existingNS.URI == ns.URI {
+					ns = existingNS
+					found = true
+					break
+				}
+			}
+		}
+
+		if !found {
+			n.Document.NamespaceList = append(n.Document.NamespaceList, ns)
+		}
+	}
+
 	newNode := &Node{
 		Name: name,
+		NS:   ns,
 	}
 	n.AppendChild(newNode)
 	return newNode


### PR DESCRIPTION
* Added support for creating a new `Document` with a namespace for the root `Node`.
* Added support for creating a `Node` with a namespace. If the namespace already exists in the document (matching by URI), then the pre-existing namespace will be used, even if the name is different.
