### PR TITLE
Added GO module support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/subchen/go-xmldom
+
+require github.com/antchfx/xpath v0.0.0-20170515025933-1f3266e77307

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/antchfx/xpath v0.0.0-20170515025933-1f3266e77307 h1:C735MoY/X+UOx6SECmHk5pVOj51h839Ph13pEoY8UmU=
+github.com/antchfx/xpath v0.0.0-20170515025933-1f3266e77307/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByNYhvtNk=


### PR DESCRIPTION
GO v1.11 module support

NOTE: It is important to create a new release including this change! See https://github.com/konsorten/go-xmldom/releases/tag/v1.1.2

WORKAROUND for projects using this library: For now, you can add the following line to the *go.mod* file: `replace github.com/subchen/go-xmldom => github.com/konsorten/go-xmldom v1.1.2`