### PR TITLE
Fix attributes namespaces exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,21 @@
 # go-xmldom
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/subchen/go-xmldom)](https://goreportcard.com/report/github.com/subchen/go-xmldom)
-[![GoDoc](https://godoc.org/github.com/subchen/go-xmldom?status.svg)](https://godoc.org/github.com/subchen/go-xmldom)
-
 XML DOM processing for Golang, supports xpath query
 
-* Parse XML into dom
-* Query node using xpath
-* Update XML using dom
+- Parse XML into dom
+- Query node using xpath
+- Update XML using dom
 
 ## Installation
 
 ```bash
-$ go get github.com/subchen/go-xmldom
+$ go get github.com/Rodion-Bozhenko/go-xmldom
 ```
 
 ## Basic Usage
 
 ```go
-xml := `<testsuite tests="2" failures="0" time="0.009" name="github.com/subchen/go-xmldom">
+xml := `<testsuite tests="2" failures="0" time="0.009" name="github.com/Rodion-Bozhenko/go-xmldom">
     <testcase classname="go-xmldom" name="ExampleParseXML" time="0.004"></testcase>
     <testcase classname="go-xmldom" name="ExampleParse" time="0.005"></testcase>
 </testsuite>`
@@ -59,7 +56,7 @@ fmt.Printf("%v: name = %v\n", c.Name, c.GetAttributeValue("name"))
 ```go
 doc := xmldom.NewDocument("testsuites")
 
-suiteNode := doc.Root.CreateNode("testsuite").SetAttributeValue("name", "github.com/subchen/go-xmldom")
+suiteNode := doc.Root.CreateNode("testsuite").SetAttributeValue("name", "github.com/Rodion-Bozhenko/go-xmldom")
 suiteNode.CreateNode("testcase").SetAttributeValue("name", "case 1")
 suiteNode.CreateNode("testcase").SetAttributeValue("name", "case 2")
 
@@ -68,4 +65,4 @@ fmt.Println(doc.XML())
 
 ## License
 
-`go-xmldom` is released under the Apache 2.0 license. See [LICENSE](https://github.com/subchen/go-xmldom/blob/master/LICENSE)
+`go-xmldom` is released under the Apache 2.0 license. See [LICENSE](https://github.com/Rodion-Bozhenko/go-xmldom/blob/master/LICENSE)

--- a/dom.go
+++ b/dom.go
@@ -4,6 +4,7 @@ package xmldom
 import (
 	"bytes"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -48,8 +49,12 @@ func Parse(r io.Reader) (*Document, error) {
 			el.Parent = e
 			el.Name = token.Name.Local
 			for _, attr := range token.Attr {
+				name := attr.Name.Local
+				if attr.Name.Space != "" {
+					name = fmt.Sprintf("%s:%s", attr.Name.Space, attr.Name.Local)
+				}
 				el.Attributes = append(el.Attributes, &Attribute{
-					Name:  attr.Name.Local,
+					Name:  name,
 					Value: attr.Value,
 				})
 			}

--- a/example_test.go
+++ b/example_test.go
@@ -2,6 +2,7 @@ package xmldom_test
 
 import (
 	"fmt"
+	"testing"
 
 	"github.com/subchen/go-xmldom"
 )
@@ -16,6 +17,7 @@ const (
 		</properties>
 		<testcase classname="go-xmldom" id="ExampleParseXML" time="0.004"></testcase>
 		<testcase classname="go-xmldom" id="ExampleParse" time="0.005"></testcase>
+    <testcase xmlns:test="mock" id="AttrNamespace"></testcase>
 	</testsuite>
 </testsuites>`
 )
@@ -148,4 +150,13 @@ func ExampleNewDocument() {
 	//     <testcase name="case 2">FAIL</testcase>
 	//   </testsuite>
 	// </testsuites>
+}
+
+func TestAttrNamespace(t *testing.T) {
+	root := xmldom.Must(xmldom.ParseXML(ExampleXml)).Root
+	node := root.FindByID("AttrNamespace")
+
+	if node.Attributes[0].Name != "xmlns:test" {
+		t.Fatalf("Expected attribute name to be xmlns:test, got=%s", node.Attributes[0].Name)
+	}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -52,6 +52,7 @@ func ExampleNode_GetChildren() {
 	// Output:
 	// testcase: id = ExampleParseXML
 	// testcase: id = ExampleParse
+	// testcase: id = AttrNamespace
 }
 
 func ExampleNode_FindByID() {
@@ -79,6 +80,7 @@ func ExampleNode_FindByName() {
 	// Output:
 	// <testcase classname="go-xmldom" id="ExampleParseXML" time="0.004" />
 	// <testcase classname="go-xmldom" id="ExampleParse" time="0.005" />
+	// <testcase xmlns:test="mock" id="AttrNamespace" />
 }
 
 func ExampleNode_Query() {
@@ -94,9 +96,10 @@ func ExampleNode_Query() {
 		fmt.Printf("%v: id = %v\n", c.Name, c.GetAttributeValue("id"))
 	}
 	// Output:
-	// children = 5
+	// children = 6
 	// testcase: id = ExampleParseXML
 	// testcase: id = ExampleParse
+	// testcase: id = AttrNamespace
 }
 
 func ExampleNode_QueryOne() {
@@ -114,7 +117,7 @@ func ExampleDocument_XML() {
 	doc := xmldom.Must(xmldom.ParseXML(ExampleXml))
 	fmt.Println(doc.XML())
 	// Output:
-	// <?xml version="1.0" encoding="UTF-8"?><!DOCTYPE junit SYSTEM "junit-result.dtd"><testsuites><testsuite tests="2" failures="0" time="0.009" name="github.com/subchen/go-xmldom"><properties><property name="go.version">go1.8.1</property></properties><testcase classname="go-xmldom" id="ExampleParseXML" time="0.004" /><testcase classname="go-xmldom" id="ExampleParse" time="0.005" /></testsuite></testsuites>
+	// <?xml version="1.0" encoding="UTF-8"?><!DOCTYPE junit SYSTEM "junit-result.dtd"><testsuites><testsuite tests="2" failures="0" time="0.009" name="github.com/subchen/go-xmldom"><properties><property name="go.version">go1.8.1</property></properties><testcase classname="go-xmldom" id="ExampleParseXML" time="0.004" /><testcase classname="go-xmldom" id="ExampleParse" time="0.005" /><testcase xmlns:test="mock" id="AttrNamespace" /></testsuite></testsuites>
 }
 
 func ExampleDocument_XMLPretty() {
@@ -130,6 +133,7 @@ func ExampleDocument_XMLPretty() {
 	//     </properties>
 	//     <testcase classname="go-xmldom" id="ExampleParseXML" time="0.004" />
 	//     <testcase classname="go-xmldom" id="ExampleParse" time="0.005" />
+	//     <testcase xmlns:test="mock" id="AttrNamespace" />
 	//   </testsuite>
 	// </testsuites>
 }

--- a/example_test.go
+++ b/example_test.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/subchen/go-xmldom"
+	"github.com/Rodion-Bozhenko/go-xmldom"
 )
 
 const (
 	ExampleXml = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE junit SYSTEM "junit-result.dtd">
 <testsuites>
-	<testsuite tests="2" failures="0" time="0.009" name="github.com/subchen/go-xmldom">
+	<testsuite tests="2" failures="0" time="0.009" name="github.com/Rodion-Bozhenko/go-xmldom">
 		<properties>
 			<property name="go.version">go1.8.1</property>
 		</properties>
@@ -40,7 +40,7 @@ func ExampleNode_GetAttribute() {
 	attr := node.FirstChild().GetAttribute("name")
 	fmt.Printf("%v = %v\n", attr.Name, attr.Value)
 	// Output:
-	// name = github.com/subchen/go-xmldom
+	// name = github.com/Rodion-Bozhenko/go-xmldom
 }
 
 func ExampleNode_GetChildren() {
@@ -117,7 +117,7 @@ func ExampleDocument_XML() {
 	doc := xmldom.Must(xmldom.ParseXML(ExampleXml))
 	fmt.Println(doc.XML())
 	// Output:
-	// <?xml version="1.0" encoding="UTF-8"?><!DOCTYPE junit SYSTEM "junit-result.dtd"><testsuites><testsuite tests="2" failures="0" time="0.009" name="github.com/subchen/go-xmldom"><properties><property name="go.version">go1.8.1</property></properties><testcase classname="go-xmldom" id="ExampleParseXML" time="0.004" /><testcase classname="go-xmldom" id="ExampleParse" time="0.005" /><testcase xmlns:test="mock" id="AttrNamespace" /></testsuite></testsuites>
+	// <?xml version="1.0" encoding="UTF-8"?><!DOCTYPE junit SYSTEM "junit-result.dtd"><testsuites><testsuite tests="2" failures="0" time="0.009" name="github.com/Rodion-Bozhenko/go-xmldom"><properties><property name="go.version">go1.8.1</property></properties><testcase classname="go-xmldom" id="ExampleParseXML" time="0.004" /><testcase classname="go-xmldom" id="ExampleParse" time="0.005" /><testcase xmlns:test="mock" id="AttrNamespace" /></testsuite></testsuites>
 }
 
 func ExampleDocument_XMLPretty() {
@@ -127,7 +127,7 @@ func ExampleDocument_XMLPretty() {
 	// <?xml version="1.0" encoding="UTF-8"?>
 	// <!DOCTYPE junit SYSTEM "junit-result.dtd">
 	// <testsuites>
-	//   <testsuite tests="2" failures="0" time="0.009" name="github.com/subchen/go-xmldom">
+	//   <testsuite tests="2" failures="0" time="0.009" name="github.com/Rodion-Bozhenko/go-xmldom">
 	//     <properties>
 	//       <property name="go.version">go1.8.1</property>
 	//     </properties>
@@ -141,7 +141,7 @@ func ExampleDocument_XMLPretty() {
 func ExampleNewDocument() {
 	doc := xmldom.NewDocument("testsuites")
 
-	testsuiteNode := doc.Root.CreateNode("testsuite").SetAttributeValue("name", "github.com/subchen/go-xmldom")
+	testsuiteNode := doc.Root.CreateNode("testsuite").SetAttributeValue("name", "github.com/Rodion-Bozhenko/go-xmldom")
 	testsuiteNode.CreateNode("testcase").SetAttributeValue("name", "case 1").Text = "PASS"
 	testsuiteNode.CreateNode("testcase").SetAttributeValue("name", "case 2").Text = "FAIL"
 
@@ -149,7 +149,7 @@ func ExampleNewDocument() {
 	// Output:
 	// <?xml version="1.0" encoding="UTF-8"?>
 	// <testsuites>
-	//   <testsuite name="github.com/subchen/go-xmldom">
+	//   <testsuite name="github.com/Rodion-Bozhenko/go-xmldom">
 	//     <testcase name="case 1">PASS</testcase>
 	//     <testcase name="case 2">FAIL</testcase>
 	//   </testsuite>

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,3 +1,3 @@
-package: github.com/subchen/go-xmldom
+package: github.com/Rodion-Bozhenko/go-xmldom
 import:
-- package: github.com/antchfx/xpath
+  - package: github.com/antchfx/xpath

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/subchen/go-xmldom
+module github.com/Rodion-Bozhenko/go-xmldom
 
 require github.com/antchfx/xpath v1.0.0


### PR DESCRIPTION
Fix issue with not including attributes' namespaces such as 'xmlns'. Motivation for that is that my app is relying on existence of 'xmlns:href' attribute in svg's 'use' tags, so absence of xlmns in attributes name is breaking my app's logic. I don't know much about namespaces in xml in general, so I only tested xmlns case.